### PR TITLE
add parentheses lambda param

### DIFF
--- a/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
+++ b/src/test/scala/com/github/takezoe/slick/blocking/SlickBlockingAPISpec.scala
@@ -293,7 +293,7 @@ class SlickBlockingAPISpec extends FunSuite {
     db.withSession { implicit session =>
       Tables.schema.create
 
-      val compiled = Compiled {i: Rep[Long] => Users.filter(_.id === i) }
+      val compiled = Compiled { (i: Rep[Long]) => Users.filter(_.id === i) }
       assert(compiled(1L).run.length === 0)
       
       // Insert
@@ -302,7 +302,7 @@ class SlickBlockingAPISpec extends FunSuite {
       assert(compiled(1L).run.length === 1)
       
       //update
-      val compiledUpdate = Compiled {n: Rep[String] => Users.filter(_.name === n).map(_.name)}
+      val compiledUpdate = Compiled { (n: Rep[String]) => Users.filter(_.name === n).map(_.name)}
       compiledUpdate("takezoe").update("João")
       
       //delete


### PR DESCRIPTION
prepare Scala 3

```
Welcome to Scala 3.1.0 (1.8.0_302, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                          
scala> val f = { i: Int => i }
-- Error:
1 |val f = { i: Int => i }
  |                 ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```