### PR TITLE
Add BlockingOracleDriver again

### DIFF
--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingDrivers.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingDrivers.scala
@@ -10,3 +10,4 @@ object BlockingPostgresDriver extends PostgresProfile with BlockingJdbcProfile
 object BlockingSQLiteDriver extends SQLiteProfile with BlockingJdbcProfile
 object BlockingDB2Driver extends DB2Profile with BlockingJdbcProfile
 object BlockingSQLServerDriver extends SQLServerProfile with BlockingJdbcProfile
+object BlockingOracleDriver extends OracleProfile with JdbcActionComponent.OneRowPerStatementOnly with BlockingJdbcProfile

--- a/src/main/scala/com/github/takezoe/slick/blocking/BlockingDrivers.scala
+++ b/src/main/scala/com/github/takezoe/slick/blocking/BlockingDrivers.scala
@@ -10,4 +10,7 @@ object BlockingPostgresDriver extends PostgresProfile with BlockingJdbcProfile
 object BlockingSQLiteDriver extends SQLiteProfile with BlockingJdbcProfile
 object BlockingDB2Driver extends DB2Profile with BlockingJdbcProfile
 object BlockingSQLServerDriver extends SQLServerProfile with BlockingJdbcProfile
-object BlockingOracleDriver extends OracleProfile with JdbcActionComponent.OneRowPerStatementOnly with BlockingJdbcProfile
+object BlockingOracleDriver
+    extends OracleProfile
+    with JdbcActionComponent.OneRowPerStatementOnly
+    with BlockingJdbcProfile


### PR DESCRIPTION
As discussed on gitter https://app.gitter.im/?updated=1.11.64#/room/#gitbucket_gitbucket:gitter.im 

Testing blocking-slick 0.0.15-RC1 brought up the problem that Oracle support is missing:

It seems like the BlockingOracleDriver had been removed here: https://github.com/gitbucket/blocking-slick/commit/dc8355df2f222551234658eaba8c0d6217ce8dec and then finally here: https://github.com/gitbucket/blocking-slick/commit/fdc380f5d66b6c345f4958df066fe68366d90120

This pull request adds BlockingOracleDriver back to blocking-slick. It is not perfect, because the OracleProfile trait does not extend the matching JdbcActionComponent like all the other traits for concrete databases do (e.g. PostgresProfile does indeed extend JdbcActionComponent.MultipleRowsPerStatementSupport ). In the case of Oracle, the matching trait is the OneRowPerStatementOnly. So that is what I had to add too in the BlockingOracleDriver object.

I tested locally with an Oracle project.

I will also open an issue with slick about the missing extension of the JdbcActionComponent. But I think the solution in this PR is good enough for now to release as-is. Or would you prefer we wait on a fix in slick itself?